### PR TITLE
Webpack 5 (Angular 12) compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,8 @@ import destination from '@turf/destination';
 import transformRotate from '@turf/transform-rotate';
 import transformScale from '@turf/transform-scale';
 
-var rotate = require('./img/rotate.png');
-var scale = require('./img/scale.png');
+var rotate = new URL('./img/rotate.png', import.meta.url);
+var scale = new URL('./img/scale.png', import.meta.url);
 
 export const SRMode = {}; //scale rotate mode
 


### PR DESCRIPTION
Loading rotate.png and scale.png by require() is with the new version of webpack (5) not possible anymore.
I suggest therefore to use new URL(), so the mode is still compatible with the latest frameworks like Angular 12.